### PR TITLE
Fix pikachu image link

### DIFF
--- a/code-along.html
+++ b/code-along.html
@@ -16,7 +16,7 @@
         <p class="description">Below, you should see an image of Pikachu:</p>
 
         <!-- 1. Something's wrong with our image tag. It should display our photo of pikachu. -->
-        <img class="pikachu" scr="https://static.wikia.nocookie.net/pokemon/images/6/6c/Char-pikachu.png/revision/latest/scale-to-width/360?cb=20190430034300" alt="Pikachu's image should appear here.">
+        <img class="pikachu" scr="https://github.com/itscodenation/int-u2l8-23-24-student-exercises/assets/9841162/0d0fda23-2dbc-4818-8273-ed3f276aa070" alt="Pikachu's image should appear here.">
 
         <!-- 2. The unordered list should include Pikachu. Add another list item. Something is also wrong with Charmander's tag...-->
         <ul class="pokemon-list">

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
 }
 
 /* 2. The image of Pikachu should have a width of 200px */
-.pikachu {
+.pikachu-img {
     width: 20px;
 }
 

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
 }
 
 /* 2. The image of Pikachu should have a width of 200px */
-.pikachu-img {
+.pikachu {
     width: 20px;
 }
 


### PR DESCRIPTION
The pikachu image link that came in the starter code does not render in Replit. 

Replaced the broken image link with a valid one, hosted by CodeNation's GitHub. (If that's a copyright problem... we can consider a different stable and valid image)  
